### PR TITLE
Redesign TimeMeasurer:

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -4,7 +4,7 @@ name: CMake on multiple platforms
 
 on:
   push:
-    branches: [ "master", "minor-optimizations" ]
+    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 

--- a/tests/unit/test_timemeasurer.cpp
+++ b/tests/unit/test_timemeasurer.cpp
@@ -6,28 +6,6 @@
 
 #include "timemeasurer.h"
 
-/// @brief RAII for cout replace with ostringsstream
-class CoutReplacer final {
-    /// @brief  no copy, no move
-    CoutReplacer(const CoutReplacer&) = delete;
-    CoutReplacer(CoutReplacer&&) = delete;
-    CoutReplacer& operator =(const CoutReplacer&) = delete;
-    CoutReplacer&& operator =(CoutReplacer&&) = delete;
-
-public:
-    CoutReplacer(std::ostringstream& toreplaceWith)
-    : originalBuffer_(std::cout.rdbuf()) {
-        std::cout.rdbuf(toreplaceWith.rdbuf());
-    }
-
-    ~CoutReplacer() {
-        std::cout.rdbuf(originalBuffer_);
-    }
-protected:
-    std::streambuf* originalBuffer_;
-};
-
-
 /// <summary>
 ///  test formatting: // "title: X,XXX,XXX ns."
 ///  title & ns.
@@ -40,11 +18,8 @@ TEST(TimeMeasurer, CheckFormatting) {
 
     std::string_view title = "measure 2 milliseconds";
     {
-        // Save the original buffer of std::cout
-        CoutReplacer  replacer(sstream);
-
         using namespace zproksi::profiler;
-        TimeMeasurer mt(title);
+        TimeMeasurer mt(title, 0, sstream);
         std::this_thread::sleep_for(std::chrono::milliseconds(2));
     }
 
@@ -84,11 +59,8 @@ TEST(TimeMeasurer, CheckSequential) {
     std::string_view title2 = "interim measure";
     std::string_view title3 = "fastest one";
     {
-        // Save the original buffer of std::cout
-        CoutReplacer  replacer(sstream);
-
         using namespace zproksi::profiler;
-        TimeMeasurer mt(title1, 2); // 2 extra titles supposed
+        TimeMeasurer mt(title1, 2, sstream); // 2 extra titles supposed
         std::this_thread::sleep_for(std::chrono::milliseconds(2));
         mt.RegisterTimePoint(title2);
         std::this_thread::sleep_for(std::chrono::milliseconds(3));

--- a/timemeasurer.cpp
+++ b/timemeasurer.cpp
@@ -7,23 +7,22 @@ namespace zproksi
 namespace profiler
 {
 
-TimeMeasurer::TimeMeasurer(const std::string_view name_, size_t amountOfExtra) {
+TimeMeasurer::TimeMeasurer(const std::string_view name_, size_t amountOfExtra, std::ostream& out)
+    : startPoint(name_, std::chrono::high_resolution_clock::now()), out(out) {
     if (amountOfExtra > 0) {
         timePoints.reserve(amountOfExtra);
     }
-    startPoint.name = name_;
-    startPoint.elapsed = std::chrono::high_resolution_clock::now();
 }
 
 TimeMeasurer::~TimeMeasurer() {
     const TIME_POINT_TYPE now = std::chrono::high_resolution_clock::now();
     for (DataVector::const_reverse_iterator rit = timePoints.crbegin(); rit != timePoints.crend(); ++rit)
     {
-        std::cout << rit->name << ": " << FormatNanoseconds(
+        out << rit->name << ": " << FormatNanoseconds(
             std::chrono::duration_cast<std::chrono::nanoseconds>(now - rit->elapsed).count()
             ) << " ns.\n";
     }
-    std::cout << startPoint.name << ": " << FormatNanoseconds(
+    out << startPoint.name << ": " << FormatNanoseconds(
         std::chrono::duration_cast<std::chrono::nanoseconds>(now - ExecutionTimePoint()).count()
         ) << " ns.\n";
 }

--- a/timemeasurer.h
+++ b/timemeasurer.h
@@ -35,7 +35,7 @@ public:
     ///    note: TimeMeasurer do not possess name of the measure - life time of the name should be longer
     /// @param name - name of the time to measure
     /// @param amountOFExtra - how many intermediate measurements supposed to be added - allocated before time serif
-    TimeMeasurer(const std::string_view name, size_t amountOfExtra = 0);
+    TimeMeasurer(const std::string_view name, size_t amountOfExtra = 0, std::ostream& out = std::cout);
 
     /// @brief all time points from later added to earlier added will be printed into std::cout
     ///   with corresponding names. (Main name provided in constructor will be printed last)
@@ -57,6 +57,7 @@ public:
 protected:
     DataVector timePoints; /// holds extra points for this measurement - can be empty
     TimePoint startPoint; /// holds start point for this class
+    std::ostream& out; // stream to output measurements
 };
 
 };// namespace profiler


### PR DESCRIPTION
 * Pass a reference to the output stream as a constructor parameter
 * Update test cases