### PR TITLE
emplace_back - variadic method usage

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -5,8 +5,14 @@ name: CMake on multiple platforms
 on:
   push:
     branches: [ "master" ]
-  pull_request:
+    paths-ignore:
+      - '**/README.md'
+      - '**/*.md'
+pull_request:
     branches: [ "master" ]
+    paths-ignore:
+      - '**/README.md'
+      - '**/*.md'
 
 jobs:
   build:

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -8,7 +8,7 @@ on:
     paths-ignore:
       - '**/README.md'
       - '**/*.md'
-pull_request:
+  pull_request:
     branches: [ "master" ]
     paths-ignore:
       - '**/README.md'

--- a/README.md
+++ b/README.md
@@ -1,23 +1,25 @@
 # timemeasurer Purpose
 
 C++ class [TimeMeasurer] for profiling of the code.
-Timing of an execution will be provided via std::cout in nanoseconds.
-The number of time serifs and the separator for printing can be customized.
+Timing of an execution will be provided via std::cout (choosen std::ostream) in nanoseconds.
+The std::ostream, number of time serifs and the separator for printing can be customized.
 
 *code conforms [cppLib] demands* (Comments; Unit Tests; Samples)
 
 # Table of Contents
 
   * [Samples of usage](#samples-of-usage)
-    * [Single measurement](#single-measurement)
+    * [Single measurement std::cout](#single-measurement-stdcout)
+    * [Single measurement std::ostream](#single-measurement-stdostream)
     * [Some measurements with help of one instance of TimeMeasurer class](#some-measurements-with-help-of-one-instance-of-timemeasurer-class)
     * [Set custom output seprator](#set-custom-output-seprator)
+    * [Full customization sample](#full-customization-sample)
   * [Unit Tests Execution](#unit-tests-execution)
   * [How to include into a project](#how-to-include-into-a-project)
 
 ## Samples of usage
 
-### Single measurement
+### Single measurement std::cout
 ```cpp
 #include "timemeasurer.h"
 
@@ -29,11 +31,33 @@ The number of time serifs and the separator for printing can be customized.
     //
     // a code whose execution time needs to be measured
     //
-}
+} // destructor of the time_measure
 ```
 ```cpp
 // possible otput in the std::cout
 test measurement: 2,425,211 ns.
+```
+
+### Single measurement std::ostream
+```cpp
+#include "timemeasurer.h"
+
+{ // scope where measurement need to done
+
+    std::ostringstream sstream;
+    {
+        using namespace zproksi::profiler;
+        TimeMeasurer time_measure("test measurement", sstream);
+
+        //
+        // a code whose execution time needs to be measured
+        //
+    } // destructor of the time_measure
+}
+```
+```cpp
+// possible data in the sstream variable after call of the time_measure destructor
+test measurement: 1,125,144 ns.
 ```
 
 ### Some measurements with help of one instance of [TimeMeasurer] class
@@ -85,6 +109,33 @@ Full Measurement: 9,382,101 ns.
 ```cpp
 // possible otput in the std::cout
 test measurement: 3:195:680 ns.
+```
+
+### Full customization sample
+```cpp
+#include "timemeasurer.h"
+
+{ // scope where measurement need to done
+    std::ostringstream sstream;
+    {
+        using namespace zproksi::profiler;
+        TimeMeasurer time_measure("Full measurement", sstream, 1, '#');
+
+        //
+        // a code whose execution time needs to be measured
+        //
+        time_measure.RegisterTimePoint("Second serif");
+        //
+        // more code whose execution time needs to be measured
+        //
+    } // destructor of the time_measure
+
+}
+```
+```cpp
+// possible otput in the sstream variable
+Second serif: 2#559#014 ns.
+Full measurement: 5#197#361 ns.
 ```
 
 ## Unit Tests Execution

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The std::ostream, number of time serifs and the separator for printing can be cu
 ```cpp
 #include "timemeasurer.h"
 
-{ // scope where measurement need to done
+{ // scope where the measurement needs to be done
 
     using namespace zproksi::profiler;
     TimeMeasurer time_measure("test measurement");
@@ -34,7 +34,7 @@ The std::ostream, number of time serifs and the separator for printing can be cu
 } // destructor of the time_measure
 ```
 ```cpp
-// possible otput in the std::cout
+// The potential otput in the std::cout
 test measurement: 2,425,211 ns.
 ```
 
@@ -42,7 +42,7 @@ test measurement: 2,425,211 ns.
 ```cpp
 #include "timemeasurer.h"
 
-{ // scope where measurement need to done
+{ // scope where the measurement needs to be done
 
     std::ostringstream sstream;
     {
@@ -56,7 +56,7 @@ test measurement: 2,425,211 ns.
 }
 ```
 ```cpp
-// possible data in the sstream variable after call of the time_measure destructor
+// The potential data in the sstream variable after the call of the time_measure destructor
 test measurement: 1,125,144 ns.
 ```
 
@@ -85,7 +85,7 @@ test measurement: 1,125,144 ns.
 } // destructor of the time_measure
 ```
 ```cpp
-// possible otput in the std::cout
+// The potential otput in the std::cout
 Fastest Time: 1,425,211 ns.
 Shorter Time: 4,140,549 ns.
 Some logic passed: 7,245,905 ns.
@@ -96,7 +96,7 @@ Full Measurement: 9,382,101 ns.
 ```cpp
 #include "timemeasurer.h"
 
-{ // scope where measurement need to done
+{ // scope where the measurement needs to be done
 
     using namespace zproksi::profiler;
     TimeMeasurer time_measure("test measurement", 0, ':');
@@ -107,7 +107,7 @@ Full Measurement: 9,382,101 ns.
 }
 ```
 ```cpp
-// possible otput in the std::cout
+// The potential otput in the std::cout
 test measurement: 3:195:680 ns.
 ```
 
@@ -115,12 +115,11 @@ test measurement: 3:195:680 ns.
 ```cpp
 #include "timemeasurer.h"
 
-{ // scope where measurement need to done
+{ // scope where the measurement needs to be done
     std::ostringstream sstream;
     {
         using namespace zproksi::profiler;
         TimeMeasurer time_measure("Full measurement", sstream, 1, '#');
-
         //
         // a code whose execution time needs to be measured
         //
@@ -133,9 +132,9 @@ test measurement: 3:195:680 ns.
 }
 ```
 ```cpp
-// possible otput in the sstream variable
-Second serif: 2#559#014 ns.
-Full measurement: 5#197#361 ns.
+// The potential data in the sstream variable after the call to the time_measure destructor
+Second serif: 59#014 ns.
+Full measurement: 1#897#361 ns.
 ```
 
 ## Unit Tests Execution

--- a/timemeasurer.cpp
+++ b/timemeasurer.cpp
@@ -7,26 +7,35 @@ namespace zproksi
 namespace profiler
 {
 
-TimeMeasurer::TimeMeasurer(const std::string_view name_, size_t amountOfExtra,
+TimeMeasurer::TimeMeasurer(const std::string_view name_, std::ostream& an_out,
+                           size_t amountOfExtra,
                            const char aseparator)
-    : separator(aseparator) {
+    : out_(an_out)
+    , separator_(aseparator) {
     if (amountOfExtra > 0) {
-        timePoints.reserve(amountOfExtra);
+        timePoints_.reserve(amountOfExtra);
     }
-    startPoint.name = name_;
-    startPoint.elapsed = std::chrono::high_resolution_clock::now();
+    startPoint_.name = name_;
+    startPoint_.elapsed = std::chrono::high_resolution_clock::now();
+}
+
+
+
+TimeMeasurer::TimeMeasurer(const std::string_view name, size_t amountOfExtra,
+                           const char aseparator)
+    : TimeMeasurer(name, std::cout, amountOfExtra, aseparator){
 }
 
 TimeMeasurer::~TimeMeasurer() {
     const TIME_POINT_TYPE now = std::chrono::high_resolution_clock::now();
-    for (DataVector::const_reverse_iterator rit = timePoints.crbegin(); rit != timePoints.crend(); ++rit) {
-        std::cout << rit->name << ": " << FormatNanoseconds(
-            std::chrono::duration_cast<std::chrono::nanoseconds>(now - rit->elapsed).count(), separator
-            ) << " ns.\n";
+    for (DataVector::const_reverse_iterator rit = timePoints_.crbegin(); rit != timePoints_.crend(); ++rit) {
+        out_ << rit->name << ": " << FormatNanoseconds(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(now - rit->elapsed).count(), separator_
+            ) << " ns." << std::endl;
     }
-    std::cout << startPoint.name << ": " << FormatNanoseconds(
-        std::chrono::duration_cast<std::chrono::nanoseconds>(now - ExecutionTimePoint()).count(), separator
-        ) << " ns.\n";
+    out_ << startPoint_.name << ": " << FormatNanoseconds(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(now - ExecutionTimePoint()).count(), separator_
+        ) << " ns." << std::endl;
 }
 
 const long long TimeMeasurer::NanosecondsElapsed(const TIME_POINT_TYPE at) const {
@@ -34,11 +43,11 @@ const long long TimeMeasurer::NanosecondsElapsed(const TIME_POINT_TYPE at) const
 }
 
 void TimeMeasurer::RegisterTimePoint(const std::string_view name) {
-    timePoints.emplace_back(name, std::chrono::high_resolution_clock::now());
+    timePoints_.emplace_back(TimePoint{name, std::chrono::high_resolution_clock::now()});
 }
 
 TimeMeasurer::TIME_POINT_TYPE TimeMeasurer::ExecutionTimePoint() const {
-    return startPoint.elapsed;
+    return startPoint_.elapsed;
 }
 
 std::string TimeMeasurer::FormatNanoseconds(const long long nanoseconds, const char separator) {

--- a/timemeasurer.cpp
+++ b/timemeasurer.cpp
@@ -34,7 +34,7 @@ const long long TimeMeasurer::NanosecondsElapsed(const TIME_POINT_TYPE at) const
 }
 
 void TimeMeasurer::RegisterTimePoint(const std::string_view name) {
-    timePoints.emplace_back(TimePoint{name, std::chrono::high_resolution_clock::now()});
+    timePoints.emplace_back(name, std::chrono::high_resolution_clock::now());
 }
 
 TimeMeasurer::TIME_POINT_TYPE TimeMeasurer::ExecutionTimePoint() const {

--- a/timemeasurer.h
+++ b/timemeasurer.h
@@ -33,8 +33,19 @@ protected:
     using DataVector = std::vector<TimePoint>;
 
 public:
-    /// @brief Full name of meaure should be passed in constructor
-    ///    note: TimeMeasurer do not possess name of the measure - life time of the name should be longer
+    /// @brief Constructs TimeMeasurer
+    ///    @note TimeMeasurer do not possess name of the measurement - remember about life time
+    /// @param name - name of the time to measure
+    /// @param an_out - output stream
+    /// @param amountOFExtra - how many intermediate measurements supposed to be added - allocated before time serif
+    /// @param aseparator - character. Separator which will be used in output
+    TimeMeasurer(const std::string_view name, std::ostream& an_out,
+                 size_t amountOfExtra = 0,
+                 const char aseparator = default_separator);
+
+    /// @brief Constructs TimeMeasurer
+    ///    @note TimeMeasurer do not possess name of the measurement - remember about life time
+    ///    @note default output stream is std::cout
     /// @param name - name of the time to measure
     /// @param amountOFExtra - how many intermediate measurements supposed to be added - allocated before time serif
     /// @param aseparator - character. Separator which will be used in output
@@ -62,9 +73,10 @@ public:
                                          const char separator = default_separator);
 
 protected:
-    DataVector timePoints; /// holds extra points for this measurement - can be empty
-    TimePoint startPoint; /// holds start point for this class
-    const char separator;
+    std::ostream& out_;      /// holds reference to the output stream
+    DataVector timePoints_;  /// holds extra points for this measurement - can be empty
+    TimePoint startPoint_;   /// holds start point for this class
+    const char separator_;   /// holds separator for time formatting
 };
 
 };// namespace profiler


### PR DESCRIPTION
std:ostringstream can be used instead of std::cout
documentation changes does not trigger rebuild/run of unit tests